### PR TITLE
Olympians route

### DIFF
--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympiansController < ApplicationController
+
+  def index
+    render json: OlympianSerializer.all_olympians
+  end
+
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -3,4 +3,25 @@ class Olympian < ApplicationRecord
 
   has_many :olympian_events
   has_many :events, through: :olympian_events
+
+  def primary_sport(events)
+    sports = Hash.new(0)
+    events.each do |event|
+      sports[event.sport] +=1
+    end
+    primary_sport = sports.max_by do |key, value|
+      value
+    end
+    primary_sport[0]
+  end
+
+  def medal_count(olympian_events)
+    medal_count = 0
+    olympian_events.each do |event|
+      if event.medal != "NA"
+        medal_count +=1
+      end
+    end
+    medal_count
+  end
 end

--- a/app/serializers/olympian_serializer.rb
+++ b/app/serializers/olympian_serializer.rb
@@ -1,0 +1,15 @@
+class OlympianSerializer
+
+  def self.all_olympians
+    olympians = Olympian.includes(:events, :olympian_events)
+    parsed_olympians = olympians.map do |olympian|
+      {name: olympian.name,
+       team: olympian.team,
+        age: olympian.age,
+      sport: olympian.primary_sport(olympian.events),
+     total_medals_won: olympian.medal_count(olympian.olympian_events)}
+    end
+    {olympians: parsed_olympians}
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      get '/olympians', to: 'olympians#index'
+    end
+  end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -8,4 +8,46 @@ describe Olympian, type: :model do
     it{should have_many :olympian_events}
     it{should have_many :events}
   end
+
+  describe 'instance methods' do
+    before :each do
+      @olympian_1 = Olympian.create(name: "Maha Abdalsalam Gouda",
+                       sex: "F",
+                       age: 18,
+                    height: 172,
+                    weight: 61,
+                      team: "Egypt")
+
+      event_1 = Event.create(games: "2016 Summer",
+                   sport: "Swimming",
+                   event: "Women's 100m Butterfly")
+      event_2 = Event.create(games: "2016 Summer",
+                   sport: "Diving",
+                   event: "Diving Women's Platform")
+      event_3 = Event.create(games: "2016 Summer",
+                   sport: "Diving",
+                   event: "Diving Women's Platform")
+
+      OlympianEvent.create(olympian_id: @olympian_1.id,
+                              event_id: event_1.id,
+                                 medal: "NA")
+      OlympianEvent.create(olympian_id: @olympian_1.id,
+                              event_id: event_2.id,
+                                 medal: "Gold")
+      OlympianEvent.create(olympian_id: @olympian_1.id,
+                              event_id: event_3.id,
+                                 medal: "Silver")
+      @events = [event_1, event_2, event_3]
+      @olympian_events = @olympian_1.olympian_events
+    end
+
+    it 'primary_sport' do
+      expect(@olympian_1.primary_sport(@events)).to eq("Diving")
+    end
+
+    it 'medal_count' do
+      expect(@olympian_1.medal_count(@olympian_events)).to eq(2)
+    end
+
+  end
 end

--- a/spec/requests/api/v1/olympians/olympian_spec.rb
+++ b/spec/requests/api/v1/olympians/olympian_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Olympians endpoint' do
+  it 'can hit endpoint successfully' do
+    get '/api/v1/olympians'
+    expect(response.status).to eq(200)
+  end
+
+  it 'retrieves correct olympian data' do
+    olympian_1 = Olympian.create(name: "Maha Abdalsalam Gouda",
+                     sex: "F",
+                     age: 18,
+                  height: 172,
+                  weight: 61,
+                    team: "Egypt")
+    event_1 = Event.create(games: "2016 Summer",
+                 sport: "Diving",
+                 event: "Diving Women's Platform")
+    OlympianEvent.create(olympian_id: olympian_1.id,
+                            event_id: event_1.id,
+                               medal: "NA")
+
+    olympian_2 = Olympian.create(name: "Ahmad Abughaush",
+                     sex: "M",
+                     age: 20,
+                  height: 178,
+                  weight: 68,
+                    team: "Jordan")
+    event_2 = Event.create(games: "2016 Summer",
+                 sport: "Taekwondo",
+                 event: "Taekwondo Men's Featherweight")
+    OlympianEvent.create(olympian_id: olympian_2.id,
+                            event_id: event_2.id,
+                               medal: "Gold")
+
+
+    get '/api/v1/olympians'
+    data = JSON.parse(response.body)
+    # binding.pry
+    expect(data["olympians"][0]["team"]).to eq("Egypt")
+  end
+end


### PR DESCRIPTION
This PR adds the first endpoint to this project. 

I went through a couple iterations to get to this point. Originally, I was fetching all olympians, then when the instance methods for medal_count and primary_sport were called, those methods were making calls to the DB to fetch the relevant event and olympian_event info.

This resulted in an 8-9 second load time, which was unacceptable.
Then I tried to leave those calls in place but include the other tables in the initial call to the db. This prevented another call to the database when doing something like `olympian.events`, but down in the instance method, made the call anyway. So using activerecord to process the medal_count and primary_sport seem to be the less than ideal solution.

I ended up passing in the events data as arguments to the instance methods and parsing it with plain old ruby. While it seems to go against the conventions from mod2, it did reduce the page load time to 3/4 of a second.

The ActiveRecord time went from 1981.9ms to 18.8ms