### PR TITLE
Olympian stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,59 @@
 - Tests can be run with: `bundle exec rspec`
 
 ### Endpoints
+
+#### GET /api/v1/olympians
+
+  This endpoint allows us to get all athletes along with some information about their event history, including their primary sport and their medal count.
+
+  Edge cases- Olympians have been created in the database from raw data that has some inconsistencies. If any property on the athlete has differences between entries in that data, they get an additional entry into our DB. The reason for this is that there is a chance that these are deliberate and they should be logged as a different participant.
+
+  In the future, this could be built out so that each athlete (by name) could have many attributes entries. This would require a schema change and a v2 for our api, as well as introduce the need to add additional filters so that athletes that share a name can still be distinguished from one another. I feel the current solution is the best with the data we have.
+
+  Sample return:
+  ```
+  {
+  "olympians": [
+    {
+      "name": "Andreea Aanei",
+      "team": "Romania",
+      "age": 22,
+      "sport": "Weightlifting",
+      "total_medals_won": 0
+    },
+    {
+      "name": "Nstor Abad Sanjun",
+      "team": "Spain",
+      "age": 23,
+      "sport": "Gymnastics",
+      "total_medals_won": 0
+    },
+    {...}
+    ]
+  }
+  ```
+
+  Update:  Have added the ability to find the youngest and oldest athletes. Simply append `?age=youngest` or `?age=oldest` as a param on the end of the URI.
+
+#### GET api/v1/olympian_stats
+
+  This endpoint retrieves some aggregate stats for all olympians.
+
+  Again I would like to use future time to expand on this functionality to allow for querying things like "number of teams represented" or "average height". These wouldn't be a heavy lift.
+
+  Another feature I'd like to add is the ability to change between metric and imperial units.
+
+  Sample response:
+  ```
+  {
+  "olympian_stats": {
+    "total_competing_olympians": 3120
+    "average_weight:" {
+      "unit": "kg",
+      "male_olympians": 75.4,
+      "female_olympians": 70.2
+    }
+    "average_age:" 26.2
+    }
+  }
+  ```

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympianStatsController < ApplicationController
+
+  def index
+    render json: OlympianStatsSerializer.all_olympians
+  end
+
+end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,16 @@
+class OlympianStatsSerializer
+
+  def self.all_olympians
+    olympians = Olympian.all
+
+    weights = {unit: "kg",
+      male_olympians: olympians.where(sex: "M").where("weight != 0").average(:weight).to_f.round(2),
+      female_olympians: olympians.where(sex: "F").where("weight != 0").average(:weight).to_f.round(2)}
+
+    parsed_stats = {total_competing_olympians: olympians.count,
+                               average_weight: weights,
+                                  average_age: olympians.where("age != 0").average(:age).to_f.round(2)}
+
+    {olympian_stats: parsed_stats}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+
+      get '/olympian_stats', to: 'olympian_stats#index'
     end
   end
 end

--- a/spec/requests/api/v1/olympians/olympian_stats_spec.rb
+++ b/spec/requests/api/v1/olympians/olympian_stats_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'Olympian stats endpoint' do
+  before :each do
+    olympian_1 = Olympian.create(name: "Maha Abdalsalam Gouda",
+                                  sex: "F",
+                                  age: 18,
+                               height: 172,
+                               weight: 61,
+                                 team: "Egypt")
+    olympian_2 = Olympian.create(name: "Ahmad Abughaush",
+                                  sex: "M",
+                                  age: 20,
+                               height: 178,
+                               weight: 68,
+                                 team: "Jordan")
+    olympian_3 = Olympian.create(name: "Ana Iulia Dascl",
+                                  sex: "F",
+                                  age: 13,
+                               height: 183,
+                               weight: 60,
+                                 team: "Romania")
+    olympian_4 = Olympian.create(name: "Nstor Abad Sanjun",
+                                  sex: "M",
+                                  age: 23,
+                               height: 167,
+                               weight: 64,
+                                 team: "Spain")
+  end
+
+  it 'can hit endpoint successfully' do
+    get '/api/v1/olympian_stats'
+    expect(response.status).to eq(200)
+  end
+
+  it 'retrieves correct olympian data' do
+    get '/api/v1/olympian_stats'
+    data = JSON.parse(response.body)
+    expect(data["olympian_stats"]["total_competing_olympians"]).to eq(4)
+  end
+
+  it 'retrieves correct average age' do
+    get '/api/v1/olympian_stats'
+    data = JSON.parse(response.body)
+    expect(data["olympian_stats"]["average_age"]).to eq(18.5)
+  end
+
+  it 'retrieves correct male average weight' do
+    get '/api/v1/olympian_stats'
+    data = JSON.parse(response.body)
+    expect(data["olympian_stats"]["average_weight"]["male_olympians"]).to eq(66)
+  end
+
+  it 'retrieves correct female average weight' do
+    get '/api/v1/olympian_stats'
+    data = JSON.parse(response.body)
+    expect(data["olympian_stats"]["average_weight"]["female_olympians"]).to eq(60.5)
+  end
+end


### PR DESCRIPTION
This endpoint retrieves some aggregate stats for all olympians.

I would like to use future time to expand on this functionality to allow for querying things like "number of teams represented" or "average height". These wouldn't be a heavy lift.

Another feature I'd like to add is the ability to change between metric and imperial units.

   Sample response:
  ```
  {
  "olympian_stats": {
    "total_competing_olympians": 3120
    "average_weight:" {
      "unit": "kg",
      "male_olympians": 75.4,
      "female_olympians": 70.2
    }
    "average_age:" 26.2
    }
  }
  ```