### PR TITLE
Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,46 @@
     }
   }
   ```
+
+#### GET api/v1/events
+
+  This endpoint returns a list of all events sorted by the sport that they are associated with.
+
+  This query turned out to be an n^2 which I am not thrilled about, however, I do think that in this situation it's ok, as even if this application is scaled for future olympic games, it will take a very long for the event and sport lists to grow to a point that this query is untenable.
+
+  Sample response:
+  ```
+  {
+  "events": [
+    {
+      "sport": "Archery",
+      "events": [
+        "Archery Women's Individual",
+        "Archery Women's Team",
+        "Archery Men's Individual",
+        "Archery Men's Team"
+      ]
+    },
+    {
+      "sport": "Gymnastics",
+      "events": [
+        "Gymnastics Men's Individual All-Around",
+        "Gymnastics Men's Floor Exercise",
+        "Gymnastics Men's Parallel Bars",
+        "Gymnastics Men's Horizontal Bar",
+        "Gymnastics Men's Rings",
+        "Gymnastics Men's Pommelled Horse",
+        "Gymnastics Men's Team All-Around",
+        "Gymnastics Men's Horse Vault",
+        "Gymnastics Women's Team All-Around",
+        "Gymnastics Women's Uneven Bars",
+        "Gymnastics Women's Balance Beam",
+        "Gymnastics Women's Individual All-Around",
+        "Gymnastics Women's Floor Exercise",
+        "Gymnastics Women's Horse Vault"
+      ]
+    },
+    {...}
+  ]
+}
+  ```

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::EventsController < ApplicationController
+
+  def index
+    render json: EventsSerializer.all_events
+  end
+
+end

--- a/app/serializers/events_serializer.rb
+++ b/app/serializers/events_serializer.rb
@@ -1,0 +1,11 @@
+class EventsSerializer
+
+  def self.all_events
+    sports = Event.distinct.pluck(:sport)
+    sorted_events = sports.map do |sport|
+      {sport: sport,
+      events: Event.where(sport: sport).pluck(:event)}
+    end
+    {events: sorted_events}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      get '/olympians', to: 'olympians#index'
-
-      get '/olympian_stats', to: 'olympian_stats#index'
+      resources :olympians, only: [:index]
+      resources :olympian_stats, only: [:index]
+      resources :events, only: [:index]
     end
   end
 end

--- a/spec/requests/api/v1/events/events_spec.rb
+++ b/spec/requests/api/v1/events/events_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Olympians endpoint' do
+  before :each do
+    event_1 = Event.create(games: "2016 Summer",
+                           sport: "Diving",
+                           event: "Diving Women's Platform")
+    event_2 = Event.create(games: "2016 Summer",
+                           sport: "Diving",
+                           event: "Diving Men's Platform")
+    event_3 = Event.create(games: "2016 Summer",
+                           sport: "Swimming",
+                           event: "Swimming Women's 100 metres Freestyle")
+  end
+
+  it 'can hit endpoint successfully' do
+    get '/api/v1/events'
+    expect(response.status).to eq(200)
+  end
+end

--- a/spec/requests/api/v1/events/events_spec.rb
+++ b/spec/requests/api/v1/events/events_spec.rb
@@ -17,4 +17,10 @@ describe 'Olympians endpoint' do
     get '/api/v1/events'
     expect(response.status).to eq(200)
   end
+
+  it 'returns all events as an array of sports' do
+    get '/api/v1/events'
+    data = JSON.parse(response.body)
+    expect(data["events"][0]["sport"]).to eq("Swimming")
+  end
 end


### PR DESCRIPTION
This endpoint returns a list of all events sorted by the sport that they are associated with.

  This query turned out to be an n^2 which I am not thrilled about, however, I do think that in this situation it's ok, as even if this application is scaled for future olympic games, it will take a very long for the event and sport lists to grow to a point that this query is untenable.

  Sample response:
  ```
  {
  "events": [
    {
      "sport": "Archery",
      "events": [
        "Archery Women's Individual",
        "Archery Women's Team",
        "Archery Men's Individual",
        "Archery Men's Team"
      ]
    },
    {
      "sport": "Gymnastics",
      "events": [
        "Gymnastics Men's Individual All-Around",
        "Gymnastics Men's Floor Exercise",
        "Gymnastics Men's Parallel Bars",
        "Gymnastics Men's Horizontal Bar",
        "Gymnastics Men's Rings",
        "Gymnastics Men's Pommelled Horse",
        "Gymnastics Men's Team All-Around",
        "Gymnastics Men's Horse Vault",
        "Gymnastics Women's Team All-Around",
        "Gymnastics Women's Uneven Bars",
        "Gymnastics Women's Balance Beam",
        "Gymnastics Women's Individual All-Around",
        "Gymnastics Women's Floor Exercise",
        "Gymnastics Women's Horse Vault"
      ]
    },
    {...}
  ]
}
  ```