### PR TITLE
Team medal count

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,32 @@
   ]
 }
   ```
+
+#### GET api/v1/team_medals
+
+This endpoint returns all teams with the count of how many medals olympians.
+
+The caveat to this endpoint is that for team sports, every member of the team contributes to the medal count.
+
+Sample response:
+```
+{
+  "team_medals": {
+    "United States": 76,
+    "Great Britain": 40,
+    "Italy": 29,
+    "Australia": 29,
+    "Russia": 28,
+    "Germany": 24,
+    "France": 23,
+    "China": 19,
+    "Canada": 18,
+    "Spain": 14,
+    "Serbia": 13,
+    "New Zealand": 12,
+    "Netherlands": 10,
+    "Jamaica": 10,
+    ...
+  }
+}
+```

--- a/app/controllers/api/v1/team_medals_controller.rb
+++ b/app/controllers/api/v1/team_medals_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::TeamMedalsController < ApplicationController
+
+  def index
+    render json: TeamsSerializer.medal_count
+  end
+
+end

--- a/app/serializers/events_serializer.rb
+++ b/app/serializers/events_serializer.rb
@@ -1,7 +1,7 @@
 class EventsSerializer
 
   def self.all_events
-    sports = Event.distinct.pluck(:sport)
+    sports = Event.distinct.pluck(:sport).sort
     sorted_events = sports.map do |sport|
       {sport: sport,
       events: Event.where(sport: sport).pluck(:event)}

--- a/app/serializers/teams_serializer.rb
+++ b/app/serializers/teams_serializer.rb
@@ -1,0 +1,11 @@
+class TeamsSerializer
+
+  def self.medal_count
+    team_medals = Olympian.joins(:olympian_events).group(:team).where('olympian_events.medal != ?', 'NA').count(:id)
+    sorted_teams = team_medals.sort_by do |key, value|
+      value
+    end
+    {team_medals: sorted_teams.reverse.to_h}
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :events, only: [:index, :show] do
         resources :medalists, only: [:index]
       end
+      resources :team_medals, only: [:index]
     end
   end
 end

--- a/spec/requests/api/v1/events/events_spec.rb
+++ b/spec/requests/api/v1/events/events_spec.rb
@@ -21,6 +21,6 @@ describe 'Olympians endpoint' do
   it 'returns all events as an array of sports' do
     get '/api/v1/events'
     data = JSON.parse(response.body)
-    expect(data["events"][0]["sport"]).to eq("Swimming")
+    expect(data["events"][0]["sport"]).to eq("Diving")
   end
 end

--- a/spec/requests/api/v1/team_medal_count_spec.rb
+++ b/spec/requests/api/v1/team_medal_count_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'Team medals endpoint' do
+  before :each do
+    olympian_1 = Olympian.create(name: "Maha Abdalsalam Gouda",
+                                  sex: "F",
+                                  age: 18,
+                               height: 172,
+                               weight: 61,
+                                 team: "Egypt")
+    event_1 = Event.create(games: "2016 Summer",
+                           sport: "Diving",
+                           event: "Diving Women's Platform")
+    OlympianEvent.create(olympian_id: olympian_1.id,
+                            event_id: event_1.id,
+                               medal: "NA")
+
+    olympian_2 = Olympian.create(name: "Ahmad Abughaush",
+                                  sex: "M",
+                                  age: 20,
+                               height: 178,
+                               weight: 68,
+                                 team: "Jordan")
+    event_2 = Event.create(games: "2016 Summer",
+                           sport: "Taekwondo",
+                           event: "Taekwondo Men's Featherweight")
+    OlympianEvent.create(olympian_id: olympian_2.id,
+                            event_id: event_2.id,
+                               medal: "Gold")
+    olympian_3 = Olympian.create(name: "Ana Iulia Dascl",
+                                  sex: "F",
+                                  age: 13,
+                               height: 183,
+                               weight: 60,
+                                 team: "Romania")
+    event_3 = Event.create(games: "2016 Summer",
+                           sport: "Swimming",
+                           event: "Swimming Women's 100 metres Freestyle")
+    OlympianEvent.create(olympian_id: olympian_3.id,
+                            event_id: event_3.id,
+                               medal: "NA")
+  end
+
+  it 'can hit endpoint successfully' do
+    get '/api/v1/team_medals'
+    expect(response.status).to eq(200)
+  end
+
+  it 'retrieves correct olympian data' do
+    get '/api/v1/team_medals'
+    data = JSON.parse(response.body)
+    expect(data["team_medals"]["Jordan"]).to eq(1)
+  end
+end


### PR DESCRIPTION
This endpoint returns all teams with the count of how many medals olympians.

The caveat to this endpoint is that for team sports, every member of the team contributes to the medal count.

Sample response:
```
{
  "team_medals": {
    "United States": 76,
    "Great Britain": 40,
    "Italy": 29,
    "Australia": 29,
    "Russia": 28,
    "Germany": 24,
    "France": 23,
    "China": 19,
    "Canada": 18,
    "Spain": 14,
    "Serbia": 13,
    "New Zealand": 12,
    "Netherlands": 10,
    "Jamaica": 10,
    ...
  }
}
```